### PR TITLE
Add option to print lines or files only

### DIFF
--- a/polyglot/core/display.py
+++ b/polyglot/core/display.py
@@ -25,7 +25,7 @@ class Display(object):
             if bool(self.text[display_text_type]):
                 print("\n")
                 table = PrettyTable()
-                table.field_names = ["Language", display_text_type]
+                table.field_names = ["Language", display_text_type.capitalize()]
                 for data in self.text[display_text_type]:
                     table.add_rows([[data, self.text[display_text_type][data]]])
                 print(colored.yellow(table))

--- a/polyglot/core/display.py
+++ b/polyglot/core/display.py
@@ -22,12 +22,13 @@ class Display(object):
         self.verify_text()
 
         for display_text_type in self.text:
-            print("\n")
-            table = PrettyTable()
-            table.field_names = ["Language", display_text_type]
-            for data in self.text[display_text_type]:
-                table.add_rows([[data, self.text[display_text_type][data]]])
-            print(colored.yellow(table))
+            if bool(self.text[display_text_type]):
+                print("\n")
+                table = PrettyTable()
+                table.field_names = ["Language", display_text_type]
+                for data in self.text[display_text_type]:
+                    table.add_rows([[data, self.text[display_text_type][data]]])
+                print(colored.yellow(table))
 
     def verify_text(self):
         assert isinstance(self.text["files"],

--- a/polyglot/core/polyglot.py
+++ b/polyglot/core/polyglot.py
@@ -76,7 +76,7 @@ class Polyglot(object):
 
         return filenames
 
-    def show(self, language_detection_file=None, display=True):
+    def show(self, language_detection_file=None, display=True, fmt=None):
         DEFAULT_LANGUAGE_DETECTION_FILE = "language.yml"
         if language_detection_file is None:
             for filename in os.listdir(os.getcwd()):
@@ -88,6 +88,14 @@ class Polyglot(object):
         data = extensions.get_extension_data()
 
         result = Result(data).show_file_information()
-        if display:
+        if display and fmt is None:
             display_text = Display(result)
-        return result
+        elif display and fmt is not None:
+            if fmt.lower() == 'l':
+                result['files'] = {}
+                display_text = Display(result)
+            elif fmt.lower() == 'f':
+                result['lines'] = {}
+                display_text = Display(result)
+        else:
+            return result

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,4 @@
 requests
 pyyaml
+prettytable
+clint


### PR DESCRIPTION
Feel free to make additional changes.

```
>>> polyglot.show(display=True, fmt="l")
+-------------------------+-------+
|         Language        | Lines |
+-------------------------+-------+
|       Ignore List       |  0.03 |
|           YAML          |  1.65 |
|       Unknown file      | 34.43 |
| GCC Machine Description |  0.08 |
|           Text          |  0.19 |
|          Python         | 63.15 |
|         HAProxy         |  0.02 |
|     reStructuredText    |  0.34 |
|           JSON          |  0.0  |
|           XML           |  0.0  |
|        Batchfile        |  0.01 |
|        PowerShell       |  0.09 |
+-------------------------+-------+
>>> polyglot.show(display=True, fmt="F")
+-------------------------+-------+
|         Language        | Files |
+-------------------------+-------+
|       Ignore List       |  0.07 |
|           YAML          |  0.07 |
|       Unknown file      | 53.35 |
| GCC Machine Description |  0.2  |
|           Text          |  2.63 |
|          Python         |  42.9 |
|         HAProxy         |  0.13 |
|     reStructuredText    |  0.2  |
|           JSON          |  0.2  |
|           XML           |  0.07 |
|        Batchfile        |  0.13 |
|        PowerShell       |  0.07 |
+-------------------------+-------+
```